### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
      - uses: actions/checkout@master
      - name: Publish to DockerHub mcliff/cdkbuild
-       uses: elgohr/Publish-Docker-Github-Action@master
+       uses: elgohr/Publish-Docker-Github-Action@v5
        with:
          name: mcliff/cdkbuild
          username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore